### PR TITLE
add train-test-split feature in TranskribusConverter

### DIFF
--- a/transkribus_hf/cli.py
+++ b/transkribus_hf/cli.py
@@ -56,6 +56,26 @@ def main():
         action="store_true",
         help="Make the repository private"
     )
+
+    parser.add_argument(
+        "--split-train",
+        type=float,
+        default=None,
+        help="Split ratio for train split. Between 0 and 1, default: None (means no split), e.g. 0.8 for 80%% train, 20%% test"
+    )
+
+    parser.add_argument(
+        "--split-seed",
+        type=int,
+        default=42,
+        help="Random seed for train/test split (default: 42)"
+    )
+
+    parser.add_argument(
+        "--split-shuffle",
+        action="store_true",
+        help="Shuffle the dataset before splitting (default: False)"
+    )
     
     parser.add_argument(
         "--stats-only",
@@ -127,7 +147,10 @@ def main():
         dataset = converter.convert(
             export_mode=args.mode,
             window_size=args.window_size,
-            overlap=args.overlap
+            overlap=args.overlap,
+            split_train=args.split_train,
+            split_seed=args.split_seed,
+            split_shuffle=args.split_shuffle,
         )
         
         if args.local_only:

--- a/transkribus_hf/converter.py
+++ b/transkribus_hf/converter.py
@@ -47,7 +47,15 @@ class TranskribusConverter:
         self.pages = self.parser.parse_zip(self.zip_path)
         print(f"Parsed {len(self.pages)} pages")
     
-    def convert(self, export_mode: str = 'text', window_size: int = 2, overlap: int = 0) -> Dataset:
+    def convert(
+            self,
+            export_mode: str = 'text',
+            window_size: int = 2,
+            overlap: int = 0,
+            split_train: Optional[float] = None,
+            split_seed: Optional[int] = 42,
+            split_shuffle: Optional[bool] = False,
+        ) -> Dataset:
         """
         Convert parsed data to a HuggingFace dataset.
         
@@ -77,6 +85,12 @@ class TranskribusConverter:
         
         dataset = exporter.export(self.pages)
         print(f"Created dataset with {len(dataset)} examples")
+
+        if split_train is not None:
+            if not (0 < split_train < 1):
+                raise ValueError("split_train must be between 0 and 1")
+            dataset = dataset.train_test_split(train_size=split_train, shuffle=split_shuffle, seed=split_seed)
+            print(f"Train size: {len(dataset['train'])}, Test size: {len(dataset['test'])}")
         
         return dataset
     


### PR DESCRIPTION
Feature to have a splitted dataset in HF.
New parameters for CLI added:
--split-train: split ratio for train split (float, default None)
--split-seed: random seed for split alg (int, default 42)
--split-shuffle: if the dataset should be shuffled before split (bool, default False)